### PR TITLE
Add per-warp permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ the mod at least once.
 ## Commands & their permissions
 
 - `/warp <warp>` - alias of `/warp <warp> {self}`  
-  Permission: `blossom.warps.warp` (default: true)
+  Permission: `blossom.warps.warp` (default: true), `blossom.warps.warp.to.<warp>` (default: true)
+  > You can set `blossom.warps.warp.to.*` to false to make `blossom.warp.warp.to.<warp>` false by default.
 - `/warp <warp> <who>` - teleport a player to a warp point called `<warp>`  
-  Permission: `blossom.warps.warp.others` (default: OP level 2)
+  Permission: `blossom.warps.warp.others` (default: OP level 2), `blossom.warps.warp.to.<warp>` (default: true)
 - `/warps` - alias of `/warps list`  
   Permission: `blossom.warps.warps` (default: true)
   - `list` - list all available warps

--- a/src/main/resources/data/blossom/lang/en_us.json
+++ b/src/main/resources/data/blossom/lang/en_us.json
@@ -4,6 +4,7 @@
   "blossom.warps.remove": "Warp %s has been successfully removed!",
   "blossom.warps.remove.failed": "Failed to remove %s!",
   "blossom.warps.not-found": "Warp \"%s\" does not exist!",
+  "blossom.warps.not-permitted": "You do not have access to warp \"%s\"!",
   "blossom.warps.list.dimension.empty": "There are no warps in %s!",
   "blossom.warps.list.all.empty": "There are no warps!",
   "blossom.warps.list.all.header": "",

--- a/src/main/resources/data/blossom/lang/zh_cn.json
+++ b/src/main/resources/data/blossom/lang/zh_cn.json
@@ -4,6 +4,7 @@
   "blossom.warps.remove": "地标 %s 已成功移除!",
   "blossom.warps.remove.failed": "地标 %s 移除失败!",
   "blossom.warps.not-found": "地标 \"%s\"并不存在!",
+  "blossom.warps.not-permitted": "地标 \"%s\"并不存在!",
   "blossom.warps.list.dimension.empty": "没有任何地标存在于 %s!",
   "blossom.warps.list.all.empty": "当前没有任何地标!",
   "blossom.warps.list.all.header": "",

--- a/src/main/resources/data/blossom/lang/zh_tw.json
+++ b/src/main/resources/data/blossom/lang/zh_tw.json
@@ -4,6 +4,7 @@
   "blossom.warps.remove": "地標 %s 已成功移除!",
   "blossom.warps.remove.failed": "地標 %s 移除失敗!",
   "blossom.warps.not-found": "地標 \"%s\"並不存在!",
+  "blossom.warps.not-permitted": "地標 \"%s\"並不存在!",
   "blossom.warps.list.dimension.empty": "沒有任何地標存在於 %s!",
   "blossom.warps.list.all.empty": "當前沒有任何地標!",
   "blossom.warps.list.all.header": "",


### PR DESCRIPTION
As discussed in discord, this PR implements off-by-default per-warp permissions. There are no breaking changes, and no permissions will need to be changed. If a server admin wants to make use of this feature, they can set the permission for any warp to false with `blossom.warps.warp.to.<warp>`, or have all warps inaccessible by default, by setting `blossom.warps.warp.to.*` to false.

Unfortunately, I haven't been able to provide translations for zh_cn or zh_tw. I've opted to use the  text for "not-found" as I think it's closest in meaning to "not permitted".